### PR TITLE
Fix SADX Game retrieval

### DIFF
--- a/SADX-Discord-Bot/Modules/bot-helper.cs
+++ b/SADX-Discord-Bot/Modules/bot-helper.cs
@@ -95,6 +95,11 @@ namespace SADX_Discord_Bot.Modules
         {
             get { return "268r391p"; }
         }
+        
+        public static string getSADXID
+        {
+            get { return "xv1pg718"; }
+        }
     }
 
 

--- a/SADX-Discord-Bot/Modules/bot-tasks.cs
+++ b/SADX-Discord-Bot/Modules/bot-tasks.cs
@@ -50,7 +50,7 @@ namespace SADX_Discord_Bot.Modules
             }
 
             //List Runs
-            string gameID = Program.Sadx.ID;
+            string gameID = BotHelper.getSADXID;
             await ListNewRuns(gameID, curChan);
             //Category Extension
             gameID = BotHelper.getCEID;

--- a/SADX-Discord-Bot/Program.cs
+++ b/SADX-Discord-Bot/Program.cs
@@ -119,7 +119,7 @@ namespace SADX_Discord_Bot
 
             try
             {
-                Sadx = Src.Games.SearchGame(name: "SADX");
+                Sadx = Src.Games.GetGame(BotHelper.getSADXID);
                 Console.WriteLine(textRdy);
 
                 if (curChan != null)


### PR DESCRIPTION
Since the Speedrun.com name for SADX changed, it looks like the search game for "sadx" gets the SADX Randomizer leaderboards instead of the base game leaderboards. This fixes getting the SADX game by using the ID instead (same as it's being done with the category extensions leaderboard)